### PR TITLE
Use proper mane to store results and artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: Execute Katalon Studio
           command: katalon-execute.sh -browserType="Chrome" -retry=0 -statusDelay=15 -testSuitePath="Test Suites/TS_RegressionTest"
-      - store-test_results:
+      - store_test_results:
           path: ./report
-      - store-artifacts:
+      - store_artifacts:
           path: ./report


### PR DESCRIPTION
Found it as I was testing on my own:
```
Error calling job: 'apis_test'
Cannot find a definition for command named store-test_results
```