### PR TITLE
issue #44: Incorrect Parameter Name Used : -testSuiteCollectionPath Instead of -testSuitePath

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,18 +1,19 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
+
 jobs:
   build:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Katalon Studio Github Action
-      uses: katalon-studio/katalon-studio-github-action@v2.1
+      uses: katalon-studio/katalon-studio-github-action@v2
       with:
           version: '7.5.5'
           projectPath: '${{ github.workspace }}'
-          args: '-noSplash -retry=0 -browserType=Chrome -statusDelay=15 -testSuitePath="Test Suites/TS_RegressionTest" -apiKey= ${{ secrets.KATALON_API_KEY }} --config -webui.autoUpdateDrivers=true'
+          args: '-noSplash -retry=0 -browserType=Chrome -statusDelay=15 -testSuitePath="Test Suites/TestSuiteDemo" -apiKey= ${{ secrets.KATALON_API_KEY}} --config -webui.autoUpdateDrivers=true'


### PR DESCRIPTION
I noticed there is incorrect documention for katalon integration with github action workflows.
In the documentation, the parameter -testSuiteCollectionPath  is mentioned for specifying the path for the test suite collection. However, Based on my experience and testing , it seems that the correct parameter name should be -testSuitePath .
The observed Result will be test suite will not be found if you use  -testSuiteCollectionPath.